### PR TITLE
Allow Null Face Rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,36 @@
-# Ignore Rundirs.
-run/
 
-# Ignore IDE Files.
+# =============================================================================
+# InfinityLib .gitignore
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# IDE Ignores
+# -----------------------------------------------------------------------------
+
+# Eclipse
 eclipse/
-.nb-gradle/
+
+# JetBrains
 .idea/
+
+# Netbeans
+.nb-gradle
 .nb-gradle-properties
+nbproject
+
+# VSCode
+.vscode
 .classpath
 .project
-.settings/
+.settings
+
+# -----------------------------------------------------------------------------
+# Gradle Ignores
+# -----------------------------------------------------------------------------
 
 # Ignore Gradle Stuff
 gradle.properties
 .gradle/
-
-# Ignore Git
-.git/
 
 # Ignore Build Files
 build/
@@ -24,14 +39,42 @@ out/
 logs/
 bin/
 
-*.iml
-*.ipr
-*.iws
-Schematic_to_Java*
-schematics/
+# -----------------------------------------------------------------------------
+# ForgeGradle Ignores
+# -----------------------------------------------------------------------------
+
+# Ignore Rundirs.
+run/
+
+# Ignore Generated Directories.
+src/generated/
+
+# -----------------------------------------------------------------------------
+# AgriCraft Ignores
+# -----------------------------------------------------------------------------
 
 # Ignore Dependencies
 libs/
 AgriCraft_Dependencies.rar
 dependencies.zip
 *.bak
+
+# -----------------------------------------------------------------------------
+# General Ignores
+# -----------------------------------------------------------------------------
+
+# Ignore Git
+.git/
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Mac Junk
+.DS_Store
+
+# Unknown Ignores
+*.iml
+*.ipr
+*.iws
+Schematic_to_Java*
+schematics/

--- a/src/main/java/com/infinityraider/infinitylib/render/tessellation/TessellatorBakedQuad.java
+++ b/src/main/java/com/infinityraider/infinitylib/render/tessellation/TessellatorBakedQuad.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 /**
  * Helper class to construct vertices
  */
@@ -46,6 +48,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
     /**
      * Face being drawn
      */
+    @Nullable
     private Direction face;
     /**
      * Icon currently drawing with
@@ -125,7 +128,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
         if (drawMode != DRAW_MODE_NOT_DRAWING) {
             for (BakedQuad quad : quads) {
                 final BakedQuad trans = transformQuads(quad);
-                if (trans.getFace() == this.face) {
+                if (this.face == null || this.face == trans.getFace()) {
                     this.quads.add(trans);
                 }
             }
@@ -182,7 +185,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
         
         if (this.vertexData.size() == this.drawMode) {
             final Direction dir = Direction.getFacingFromVector(this.getNormal().getX(), this.getNormal().getY(), this.getNormal().getZ());
-            if (dir == this.face) {
+            if (this.face == null || this.face == dir) {
                 BakedQuadBuilder builder = new BakedQuadBuilder();
                 builder.setQuadTint(this.getTintIndex());
                 builder.setApplyDiffuseLighting(this.getApplyDiffuseLighting());
@@ -199,7 +202,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
 
     @Override
     public void drawScaledFace(float minX, float minY, float maxX, float maxY, Direction face, TextureAtlasSprite icon, float offset) {
-        if (this.face == face) {
+        if (this.face == null || this.face == face) {
             super.drawScaledFace(minX, minY, maxX, maxY, face, icon, offset);
         }
     }
@@ -222,7 +225,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
         return this;
     }
 
-    public TessellatorBakedQuad setCurrentFace(Direction face) {
+    public TessellatorBakedQuad setCurrentFace(@Nullable Direction face) {
         this.face = face;
         return this;
     }

--- a/src/main/java/com/infinityraider/infinitylib/render/tessellation/TessellatorBakedQuad.java
+++ b/src/main/java/com/infinityraider/infinitylib/render/tessellation/TessellatorBakedQuad.java
@@ -13,7 +13,9 @@ import net.minecraftforge.client.model.pipeline.BakedQuadBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -48,8 +50,8 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
     /**
      * Face being drawn
      */
-    @Nullable
-    private Direction face;
+    @Nonnull
+    private Face face;
     /**
      * Icon currently drawing with
      */
@@ -67,6 +69,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
         this.quads = new ArrayList<>();
         this.vertexData = new ArrayList<>();
         this.drawMode = DRAW_MODE_NOT_DRAWING;
+        this.face = Face.NONE;
     }
 
     /**
@@ -112,7 +115,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
             vertexData.clear();
             this.drawMode = DRAW_MODE_NOT_DRAWING;
             this.textureFunction = null;
-            this.face = null;
+            this.face = Face.NONE;
         } else {
             throw new RuntimeException("NOT CONSTRUCTING VERTICES");
         }
@@ -128,7 +131,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
         if (drawMode != DRAW_MODE_NOT_DRAWING) {
             for (BakedQuad quad : quads) {
                 final BakedQuad trans = transformQuads(quad);
-                if (this.face == null || this.face == trans.getFace()) {
+                if (this.face.accepts(trans.getFace())) {
                     this.quads.add(trans);
                 }
             }
@@ -185,7 +188,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
         
         if (this.vertexData.size() == this.drawMode) {
             final Direction dir = Direction.getFacingFromVector(this.getNormal().getX(), this.getNormal().getY(), this.getNormal().getZ());
-            if (this.face == null || this.face == dir) {
+            if (this.face.accepts(dir)) {
                 BakedQuadBuilder builder = new BakedQuadBuilder();
                 builder.setQuadTint(this.getTintIndex());
                 builder.setApplyDiffuseLighting(this.getApplyDiffuseLighting());
@@ -202,7 +205,7 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
 
     @Override
     public void drawScaledFace(float minX, float minY, float maxX, float maxY, Direction face, TextureAtlasSprite icon, float offset) {
-        if (this.face == null || this.face == face) {
+        if (this.face.accepts(face)) {
             super.drawScaledFace(minX, minY, maxX, maxY, face, icon, offset);
         }
     }
@@ -226,7 +229,48 @@ public class TessellatorBakedQuad extends TessellatorAbstractBase {
     }
 
     public TessellatorBakedQuad setCurrentFace(@Nullable Direction face) {
+        return this.setCurrentFace(Face.fromDirection(face));
+    }
+
+    public TessellatorBakedQuad setCurrentFace(@Nonnull Face face) {
         this.face = face;
         return this;
+    }
+
+    public enum Face {
+        NONE(false),
+        GENERAL(true),
+        DOWN(Direction.DOWN),
+        UP(Direction.UP),
+        NORTH(Direction.NORTH),
+        SOUTH(Direction.SOUTH),
+        WEST(Direction.WEST),
+        EAST(Direction.EAST);
+
+        private final Predicate<Direction> test;
+
+        Face(boolean general) {
+            this(dir -> general);
+        }
+
+        Face(Direction direction) {
+            this(dir -> dir == direction);
+        }
+
+        Face(Predicate<Direction> test) {
+            this.test = test;
+        }
+
+        public boolean accepts(@Nullable Direction direction) {
+            return this.test.test(direction);
+        }
+
+        @Nonnull
+        public static Face fromDirection(@Nullable Direction direction) {
+            if(direction == null) {
+                return GENERAL;
+            }
+            return values()[direction.ordinal() + 2];
+        }
     }
 }


### PR DESCRIPTION
- Fix: Allow Tesselator to render null faces.

@InfinityRaider I don't know what you think of this? The forge docs seem to say that the null face is used for rendering in the inventory, and stepping through it with the debugger shows that the face does get set to null occasionally.